### PR TITLE
Fix carousel display wrong selectedIndex

### DIFF
--- a/SwiftUI-Beauty/View Pages/Photos/PhotosView.swift
+++ b/SwiftUI-Beauty/View Pages/Photos/PhotosView.swift
@@ -10,8 +10,6 @@ import Kingfisher
 
 struct PhotosView: View {
     @ObservedObject var viewModel: PhotosViewModel
-    @State private var isPresented = false
-    @State private var selectedIndex = 0
 
     private let gridItems = [GridItem(.flexible()), GridItem(.flexible())]
 
@@ -20,8 +18,8 @@ struct PhotosView: View {
             LazyVGrid(columns: gridItems, spacing: 15) {
                 ForEach(0..<viewModel.urls.count, id: \.self) { index in
                     Button(action: {
-                        self.isPresented = true
-                        self.selectedIndex = index
+                        viewModel.selectedIndex = index
+                        viewModel.isPresented.toggle()
                     }, label: {
                         KFImage(viewModel.urls[index])
                             .cancelOnDisappear(true)
@@ -38,10 +36,10 @@ struct PhotosView: View {
                 }
             }
             .padding(15)
-            .fullScreenCover(isPresented: $isPresented) {
+            .fullScreenCover(isPresented: $viewModel.isPresented) {
                 CarouselImageView(urls: viewModel.urls)
                     .background(Color.black.ignoresSafeArea())
-                    .environment(\.selectedIndex, selectedIndex)
+                    .environment(\.selectedIndex, viewModel.selectedIndex)
             }
         }
         .onAppear(perform: viewModel.fetchPhotos)

--- a/SwiftUI-Beauty/View Pages/Photos/PhotosViewModel.swift
+++ b/SwiftUI-Beauty/View Pages/Photos/PhotosViewModel.swift
@@ -12,6 +12,9 @@ final class PhotosViewModel: ObservableObject {
     @Published var urls: [URL] = []
     @Published var error: CustomError? = nil
     @Published var isFetchingPhotos: Bool = false
+    
+    @Published var isPresented = false
+    @Published var selectedIndex = 0
 
     var postTitle: String {
         post.title


### PR DESCRIPTION
### About
- Fix carousel display wrong selectedIndex, by moving variables into ObservedObject viewModel
- Currently not sure why in `fullScreenCover`, the `@State selectedIndex` only get 0, until it is changed the 2nd time...